### PR TITLE
Add convert command

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,11 +576,11 @@ $ mnemonikey recover -only signing -sig-index 1 -self-cert=false | gpg --import
 
 #### Generate a master key and signing subkey (starts at default index 0).
 
-<img width="700" src="https://user-images.githubusercontent.com/31221309/205466128-53f94d4d-7a6d-445b-8e5e-76001b859b43.gif">
+<img width="700" src="https://github.com/kklash/mnemonikey/assets/31221309/6b5c4de0-0898-4829-b751-dcea5a6560cc">
 
 #### Derive the new signing subkey at index 1, and revoke the old one at index 0.
 
-<img width="700" src="https://user-images.githubusercontent.com/31221309/205466129-8f9528e8-0ee8-49ec-9f98-3197d79bc103.gif">
+<img width="700" src="https://github.com/kklash/mnemonikey/assets/31221309/6420d764-7ba3-42ac-994d-e31317598057">
 
 `-self-cert=false` is an optional flag which tells Mnemonikey not to output the master key's self-certification signature on the user ID. This is useful when minting new subkeys, in a situation where you already have the master key stored safely in your keyring. It prevents adding unneeded extra certification signatures to your keychain.
 

--- a/cmd/mnemonikey/common_opts.go
+++ b/cmd/mnemonikey/common_opts.go
@@ -102,3 +102,29 @@ func (opts *GenerateRecoverOptions) DecodeOnlyKeyTypes() (
 	}
 	return
 }
+
+// RecoverConvertOptions is the set of options common to both recover and convert commands.
+type RecoverConvertOptions struct {
+	SimpleInput bool
+	WordFile    string
+}
+
+// AddFlags registers the common set of options as command line flags.
+func (opts *RecoverConvertOptions) AddFlags(flags *flag.FlagSet) {
+	flags.BoolVar(
+		&opts.SimpleInput,
+		"simple",
+		false,
+		"Revert to a simpler terminal input mechanism for entering the recovery "+
+			"phrase. Useful if the fancy terminal manipulation used by the default "+
+			"input mode doesn't work on your system.",
+	)
+
+	flags.StringVar(
+		&opts.WordFile,
+		"word-file",
+		"",
+		"Read the words of the mnemonic from this `file`. Words should be separated by whitespace "+
+			"and the file should contain the exact words. Useful for debugging.",
+	)
+}

--- a/cmd/mnemonikey/common_opts.go
+++ b/cmd/mnemonikey/common_opts.go
@@ -8,6 +8,21 @@ import (
 	"github.com/kklash/mnemonikey"
 )
 
+// CommonOptions is a set of options common to every command.
+type CommonOptions struct {
+	Verbose bool
+}
+
+// AddFlags registers the common set of options as command line flags.
+func (opts *CommonOptions) AddFlags(flags *flag.FlagSet) {
+	flags.BoolVar(
+		&opts.Verbose,
+		"verbose",
+		false,
+		"Print extra debugging information to stderr when building keys.",
+	)
+}
+
 // GenerateRecoverOptions is the set of options common to both recover and generate commands.
 type GenerateRecoverOptions struct {
 	Name         string
@@ -15,7 +30,6 @@ type GenerateRecoverOptions struct {
 	TTL          string
 	EncryptKeys  bool
 	OnlyKeyTypes string
-	Verbose      bool
 }
 
 // AddFlags registers the common set of options as command line flags.
@@ -56,13 +70,6 @@ func (opts *GenerateRecoverOptions) AddFlags(flags *flag.FlagSet) {
 		"",
 		"Only output a subset key containing the given key `types` as PGP packets. A comma-delimited "+
 			"list of the following possible values:  master | encryption | signing | authentication",
-	)
-
-	flags.BoolVar(
-		&opts.Verbose,
-		"verbose",
-		false,
-		"Print extra debugging information to stderr when building keys.",
 	)
 }
 

--- a/cmd/mnemonikey/common_opts.go
+++ b/cmd/mnemonikey/common_opts.go
@@ -105,8 +105,8 @@ func (opts *GenerateRecoverOptions) DecodeOnlyKeyTypes() (
 
 // RecoverConvertOptions is the set of options common to both recover and convert commands.
 type RecoverConvertOptions struct {
-	SimpleInput bool
-	WordFile    string
+	SimpleInput   bool
+	InputWordFile string
 }
 
 // AddFlags registers the common set of options as command line flags.
@@ -121,10 +121,27 @@ func (opts *RecoverConvertOptions) AddFlags(flags *flag.FlagSet) {
 	)
 
 	flags.StringVar(
-		&opts.WordFile,
-		"word-file",
+		&opts.InputWordFile,
+		"in-word-file",
 		"",
 		"Read the words of the mnemonic from this `file`. Words should be separated by whitespace "+
 			"and the file should contain the exact words. Useful for debugging.",
+	)
+}
+
+// GenerateConvertOptions is the set of options common to both generate and convert commands.
+type GenerateConvertOptions struct {
+	OutputWordFile string
+}
+
+// AddFlags registers the common set of options as command line flags.
+func (opts *GenerateConvertOptions) AddFlags(flags *flag.FlagSet) {
+	flags.StringVar(
+		&opts.OutputWordFile,
+		"out-word-file",
+		"",
+		"Write the words of the recovery phrase to this `file` in PLAIN TEXT. Useful for debugging. "+
+			"Do not use this if you care about keeping your keys safe. Words will be separated by a "+
+			"single space. The file will contain the exact words and nothing else.",
 	)
 }

--- a/cmd/mnemonikey/convert.go
+++ b/cmd/mnemonikey/convert.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+
+	"github.com/kklash/mnemonikey"
+)
+
+type ConvertOptions struct {
+	CommonOptions
+	RecoverConvertOptions
+
+	EncryptPhrase  bool
+	OutputWordFile string
+}
+
+var ConvertCommand = &Command[ConvertOptions]{
+	Name:        "mnemonikey convert",
+	Description: "Add, change, or remove an encryption password on an existing mnemonic recovery phrase.",
+	UsageExamples: []string{
+		"mnemonikey convert",
+		"mnemonikey convert -encrypt",
+		"mnemonikey convert -simple",
+		"mnemonikey convert -word-file /etc/words",
+		"mnemonikey convert -word-file /etc/words -out-word-file /etc/new-words",
+	},
+	AddFlags: func(flags *flag.FlagSet, opts *ConvertOptions) {
+		opts.CommonOptions.AddFlags(flags)
+		opts.RecoverConvertOptions.AddFlags(flags)
+
+		flags.BoolVar(
+			&opts.EncryptPhrase,
+			"encrypt-phrase",
+			false,
+			"If true, encrypt the recovery phrase with a new password. The resulting phrase will "+
+				"require the same password for later recovery. If false, output a plaintext phrase.",
+		)
+
+		flags.StringVar(
+			&opts.OutputWordFile,
+			"out-word-file",
+			"",
+			"Write the words of the recovery phrase to this `file` in PLAIN TEXT. Useful for debugging. "+
+				"Do not use this if you care about keeping your keys safe. Words will be separated by a "+
+				"single space. The file will contain the exact words and nothing else.",
+		)
+	},
+	Execute: func(opts *ConvertOptions, args []string) error {
+		return decodeAndConvertPhrase(opts)
+	},
+}
+
+func decodeAndConvertPhrase(opts *ConvertOptions) (err error) {
+	seed, decodedMnemonic, err := decodeMnemonicFromInput(opts.RecoverConvertOptions, opts.Verbose)
+	if err != nil {
+		return err
+	}
+
+	var recoveryMnemonic []string
+	if opts.EncryptPhrase {
+		phraseEncryptionPassword, err := userInputPassword("Enter phrase encryption password: ", true)
+		if err != nil {
+			return err
+		}
+		recoveryMnemonic, err = mnemonikey.EncodeMnemonicEncrypted(
+			seed,
+			decodedMnemonic.CreationOffset(),
+			phraseEncryptionPassword,
+			rand.Reader,
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		recoveryMnemonic, err = mnemonikey.EncodeMnemonicPlaintext(seed, decodedMnemonic.CreationOffset())
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.WordFile == "" {
+		printMnemonic(recoveryMnemonic)
+	} else {
+		if err := saveMnemonic(recoveryMnemonic, opts.WordFile); err != nil {
+			return fmt.Errorf("failed to write words to file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/mnemonikey/convert.go
+++ b/cmd/mnemonikey/convert.go
@@ -11,6 +11,7 @@ import (
 type ConvertOptions struct {
 	CommonOptions
 	RecoverConvertOptions
+	GenerateConvertOptions
 
 	EncryptPhrase  bool
 	OutputWordFile string
@@ -29,6 +30,7 @@ var ConvertCommand = &Command[ConvertOptions]{
 	AddFlags: func(flags *flag.FlagSet, opts *ConvertOptions) {
 		opts.CommonOptions.AddFlags(flags)
 		opts.RecoverConvertOptions.AddFlags(flags)
+		opts.GenerateConvertOptions.AddFlags(flags)
 
 		flags.BoolVar(
 			&opts.EncryptPhrase,
@@ -36,15 +38,6 @@ var ConvertCommand = &Command[ConvertOptions]{
 			false,
 			"If true, encrypt the recovery phrase with a new password. The resulting phrase will "+
 				"require the same password for later recovery. If false, output a plaintext phrase.",
-		)
-
-		flags.StringVar(
-			&opts.OutputWordFile,
-			"out-word-file",
-			"",
-			"Write the words of the recovery phrase to this `file` in PLAIN TEXT. Useful for debugging. "+
-				"Do not use this if you care about keeping your keys safe. Words will be separated by a "+
-				"single space. The file will contain the exact words and nothing else.",
 		)
 	},
 	Execute: func(opts *ConvertOptions, args []string) error {
@@ -80,10 +73,10 @@ func decodeAndConvertPhrase(opts *ConvertOptions) (err error) {
 		}
 	}
 
-	if opts.WordFile == "" {
+	if opts.InputWordFile == "" {
 		printMnemonic(recoveryMnemonic)
 	} else {
-		if err := saveMnemonic(recoveryMnemonic, opts.WordFile); err != nil {
+		if err := saveMnemonic(recoveryMnemonic, opts.InputWordFile); err != nil {
 			return fmt.Errorf("failed to write words to file: %w", err)
 		}
 	}

--- a/cmd/mnemonikey/generate.go
+++ b/cmd/mnemonikey/generate.go
@@ -19,8 +19,8 @@ var DefaultName = "anonymous"
 type GenerateOptions struct {
 	CommonOptions
 	GenerateRecoverOptions
+	GenerateConvertOptions
 
-	WordFile      string
 	EncryptPhrase bool
 }
 
@@ -38,15 +38,7 @@ var GenerateCommand = &Command[GenerateOptions]{
 	AddFlags: func(flags *flag.FlagSet, opts *GenerateOptions) {
 		opts.CommonOptions.AddFlags(flags)
 		opts.GenerateRecoverOptions.AddFlags(flags)
-
-		flags.StringVar(
-			&opts.WordFile,
-			"word-file",
-			"",
-			"Write the words of the recovery phrase to this `file` in PLAIN TEXT. Useful for debugging. "+
-				"Do not use this if you care about keeping your keys safe. Words will be separated by a "+
-				"single space. The file will contain the exact words and nothing else.",
-		)
+		opts.GenerateConvertOptions.AddFlags(flags)
 
 		flags.BoolVar(
 			&opts.EncryptPhrase,
@@ -79,9 +71,9 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 		}
 	}
 
-	if opts.WordFile != "" {
-		if _, err := os.Stat(opts.WordFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("refused to write word-file to %s: file already exists", opts.WordFile)
+	if opts.OutputWordFile != "" {
+		if _, err := os.Stat(opts.OutputWordFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("refused to write word-file to %s: file already exists", opts.OutputWordFile)
 		}
 	}
 
@@ -136,8 +128,8 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 		}
 	}
 
-	if opts.WordFile != "" {
-		if err := saveMnemonic(recoveryMnemonic, opts.WordFile); err != nil {
+	if opts.OutputWordFile != "" {
+		if err := saveMnemonic(recoveryMnemonic, opts.OutputWordFile); err != nil {
 			return fmt.Errorf("failed to write words to file: %w", err)
 		}
 	}
@@ -152,7 +144,7 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 	fmt.Println(pgpArmorKey)
 	eprint(colorEnd)
 
-	if opts.WordFile == "" {
+	if opts.OutputWordFile == "" {
 		printMnemonic(recoveryMnemonic)
 	}
 

--- a/cmd/mnemonikey/generate.go
+++ b/cmd/mnemonikey/generate.go
@@ -17,6 +17,7 @@ import (
 var DefaultName = "anonymous"
 
 type GenerateOptions struct {
+	CommonOptions
 	Common        GenerateRecoverOptions
 	WordFile      string
 	EncryptPhrase bool
@@ -34,6 +35,7 @@ var GenerateCommand = &Command[GenerateOptions]{
 		"mnemonikey generate -ttl 17w",
 	},
 	AddFlags: func(flags *flag.FlagSet, opts *GenerateOptions) {
+		opts.CommonOptions.AddFlags(flags)
 		opts.Common.AddFlags(flags)
 
 		flags.StringVar(
@@ -141,7 +143,7 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 		}
 	}
 
-	if opts.Common.Verbose {
+	if opts.Verbose {
 		eprintf("Generated OpenPGP private key with %d bits of entropy:\n", mnemonikey.EntropyBitCount)
 		printKeyDebugInfo(mnk)
 		eprintln()

--- a/cmd/mnemonikey/generate.go
+++ b/cmd/mnemonikey/generate.go
@@ -71,12 +71,6 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 		}
 	}
 
-	if opts.OutputWordFile != "" {
-		if _, err := os.Stat(opts.OutputWordFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("refused to write word-file to %s: file already exists", opts.OutputWordFile)
-		}
-	}
-
 	outputMasterKey, subkeyTypes, err := opts.DecodeOnlyKeyTypes()
 	if err != nil {
 		return err
@@ -169,6 +163,12 @@ func printMnemonic(words []string) {
 }
 
 func saveMnemonic(words []string, wordFile string) error {
+	if _, err := os.Stat(wordFile); err == nil {
+		return fmt.Errorf("refused to write word-file to %s: file already exists", wordFile)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to write word-file to %s: path is not accessible: %w", wordFile, err)
+	}
+
 	wordFileContent := strings.Join(words, " ") + "\n"
 	if err := os.WriteFile(wordFile, []byte(wordFileContent), 0600); err != nil {
 		return fmt.Errorf("failed to write words to file: %w", err)

--- a/cmd/mnemonikey/main.go
+++ b/cmd/mnemonikey/main.go
@@ -12,6 +12,7 @@ type RootOptions struct {
 var subcommands = map[string]Runner{
 	"generate": GenerateCommand,
 	"recover":  RecoverCommand,
+	"convert":  ConvertCommand,
 }
 
 var RootCommand = &Command[RootOptions]{
@@ -21,6 +22,7 @@ var RootCommand = &Command[RootOptions]{
 		"mnemonikey <COMMAND> [help | --help | -h] [OPTIONS]\n",
 		"mnemonikey generate  - Generate a new OpenPGP private key and display its recovery phrase.",
 		"mnemonikey recover   - Recover an OpenPGP private key from a mnemonic recovery phrase.",
+		"mnemonikey convert   - Convert between mnemonic recovery phrase formats.",
 	},
 	Execute: func(_ *RootOptions, args []string) error {
 		if len(args) == 0 {

--- a/cmd/mnemonikey/recover.go
+++ b/cmd/mnemonikey/recover.go
@@ -16,6 +16,7 @@ import (
 const maxSubkeyIndex uint = 0xFFFF
 
 type RecoverOptions struct {
+	CommonOptions
 	Common      GenerateRecoverOptions
 	SimpleInput bool
 	WordFile    string
@@ -42,6 +43,7 @@ var RecoverCommand = &Command[RecoverOptions]{
 		"mnemonikey recover -simple -name myuser",
 	},
 	AddFlags: func(flags *flag.FlagSet, opts *RecoverOptions) {
+		opts.CommonOptions.AddFlags(flags)
 		opts.Common.AddFlags(flags)
 
 		flags.BoolVar(
@@ -140,7 +142,7 @@ func recoverAndPrintKey(opts *RecoverOptions) error {
 		return err
 	}
 
-	if opts.Common.Verbose {
+	if opts.Verbose {
 		eprintln("Decoded mnemonic recovery phrase:")
 		printDebugInfo(os.Stderr, [][2]string{
 			{"version", strconv.Itoa(int(decodedMnemonic.Version))},
@@ -194,7 +196,7 @@ func recoverAndPrintKey(opts *RecoverOptions) error {
 		return err
 	}
 
-	if opts.Common.Verbose {
+	if opts.Verbose {
 		eprintln("Re-derived OpenPGP key:")
 		printKeyDebugInfo(mnk)
 		eprintln()

--- a/cmd/mnemonikey/recover.go
+++ b/cmd/mnemonikey/recover.go
@@ -87,8 +87,8 @@ func decodeMnemonicFromInput(
 		words []string
 		err   error
 	)
-	if opts.WordFile != "" {
-		words, err = readWordFile(opts.WordFile)
+	if opts.InputWordFile != "" {
+		words, err = readWordFile(opts.InputWordFile)
 	} else if opts.SimpleInput {
 		words, err = userInputMnemonicSimple()
 	} else {

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,113 @@
+package mnemonikey
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"math/big"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/kklash/mnemonikey/mnemonic"
+)
+
+func encodeMnemonic(version MnemonicVersion, payloadBitBuffer *bitBuffer) ([]string, error) {
+	// Compute & append checksum.
+	checksum := checksumMask & crc32.ChecksumIEEE(payloadBitBuffer.Bytes())
+	payloadBitBuffer.AppendTrailingBits(big.NewInt(int64(checksum)), ChecksumBitCount)
+
+	expectedBitLen := version.payloadBitCount()
+	actualBitLen := payloadBitBuffer.BitLen()
+	if actualBitLen != expectedBitLen {
+		return nil, fmt.Errorf(
+			"payload has incorrect bit length, wanted %d for version %d, got %d bits",
+			expectedBitLen, version, actualBitLen,
+		)
+	}
+
+	indices, err := mnemonic.EncodeToIndices(payloadBitBuffer.Int(), payloadBitBuffer.BitLen())
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode payload to indices: %w", err)
+	}
+
+	words, err := mnemonic.EncodeToWords(indices)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode indices to words: %w", err)
+	}
+	return words, nil
+}
+
+// EncodeMnemonicPlaintext encodes the given seed and creationOffset into an English mnemonic
+// recovery phrase. The recovery phrase alone is sufficient to recover the entire set of keys.
+func EncodeMnemonicPlaintext(seed *Seed, creationOffset uint32) ([]string, error) {
+	if err := seed.Era().check(); err != nil {
+		return nil, err
+	}
+
+	// Version 0 indicates a plaintext phrase.
+	version := MnemonicVersion(0)
+
+	payloadBitBuffer := newBitBuffer(big.NewInt(int64(version)), MnemonicVersionBitCount)
+	payloadBitBuffer.AppendTrailingBits(seed.Int(), EntropyBitCount)
+	payloadBitBuffer.AppendTrailingBits(big.NewInt(int64(creationOffset)), CreationOffsetBitCount)
+
+	return encodeMnemonic(version, payloadBitBuffer)
+}
+
+// EncodeMnemonicEncrypted encodes the given seed and creationOffset into an English
+// mnemonic recovery phrase. The recovery phrase is encrypted with the given password
+// so that the same password must be used upon recovery to decrypt the phrase.
+//
+// Without the password, someone in possession of an encrypted phrase would see the key's
+// metadata (version, creation time) but would not be able to use it to derive the correct
+// PGP private keys.
+func EncodeMnemonicEncrypted(
+	seed *Seed,
+	creationOffset uint32,
+	password []byte,
+	random io.Reader,
+) ([]string, error) {
+	if err := seed.Era().check(); err != nil {
+		return nil, err
+	}
+
+	if len(password) == 0 {
+		return nil, errors.New("cannot encrypt recovery phrase with empty password")
+	}
+
+	// Version 1 indicates an encrypted phrase.
+	version := MnemonicVersion(1)
+	payloadBitBuffer := newBitBuffer(big.NewInt(int64(version)), MnemonicVersionBitCount)
+
+	saltInt, err := rand.Int(random, big.NewInt(int64(1<<SaltBitCount)))
+	if err != nil {
+		return nil, err
+	}
+
+	encSeedSaltBuf := newBitBuffer(saltInt, SaltBitCount)
+	encSeedSaltBuf.AppendTrailingBits(big.NewInt(int64(creationOffset)), CreationOffsetBitCount)
+
+	encSeedKey := argon2.IDKey(password, encSeedSaltBuf.Bytes(), argonTimeFactor, argonMemoryFactor, argonThreads, 17)
+	block, err := aes.NewCipher(encSeedKey[:16])
+	if err != nil {
+		return nil, err
+	}
+	encSeed := make([]byte, 16)
+	block.Encrypt(encSeed, seed.Bytes())
+	encSeedVerify := big.NewInt(int64(encSeedKey[16] & encSeedVerifyMask))
+
+	// Append:
+	// - encSeed
+	// - salt
+	// - encSeedVerify
+	// - creationOffset
+	payloadBitBuffer.AppendTrailingBits(new(big.Int).SetBytes(encSeed), EntropyBitCount)
+	payloadBitBuffer.AppendTrailingBits(saltInt, SaltBitCount)
+	payloadBitBuffer.AppendTrailingBits(encSeedVerify, EncSeedVerifyBitCount)
+	payloadBitBuffer.AppendTrailingBits(big.NewInt(int64(creationOffset)), CreationOffsetBitCount)
+
+	return encodeMnemonic(version, payloadBitBuffer)
+}

--- a/recovery.go
+++ b/recovery.go
@@ -55,6 +55,11 @@ func (dm *DecodedMnemonic) Creation() time.Time {
 	return EpochStart.Add(time.Duration(dm.creationOffset) * EpochIncrement)
 }
 
+// CreationOffset returns the raw creation offset value encoded in the mnemonic phrase.
+func (dm *DecodedMnemonic) CreationOffset() uint32 {
+	return dm.creationOffset
+}
+
 // DecryptSeed decrypts the encrypted entropy in the mnemonic using the
 // given password. Returns ErrMnemonicDecryption if the password was
 // incorrect.


### PR DESCRIPTION
Fixes #29 

Adds conversion between encrypted and plaintext recovery phrases, and support for changing passwords of existing encrypted phrases. 

Usage documentation will be handled as part of #35, but the basic usage is:


### Decrypt a Recovery Phrase
```
mnemonikey convert
```

### Encrypt (or re-encrypt) a Recovery Phrase

```
mnemonikey convert -encrypt
```

----------

As a byproduct, I've updated the `mnemonikey` package's API to support encoding operations on `mnemonikey.Seed` instances without requiring the extra work to derive PGP keys into a `mnemonikey.Mnemonikey` first.

