### PR TITLE
feat: add reproducible build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz"
+          goversion: "https://dl.google.com/go/go1.20.4.linux-amd64.tar.gz"
           project_path: "./cmd/mnemonikey"
           binary_name: "mnemonikey"
           extra_files: LICENSE README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  GOVERSION: "1.19.4"
+  GOVERSION: "1.20.4"
   GOPATH: "/tmp/gopath"
   GOROOT: "/tmp/go"
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/build
 /mnemonikey
 /cmd/mnemonikey/mnemonikey

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /mnemonikey
+/mnemonikey.exe
 /cmd/mnemonikey/mnemonikey
+/cmd/mnemonikey/mnemonikey.exe

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ To use `mnemonikey` as a Golang library:
 $ go get -u github.com/kklash/mnemonikey
 ```
 
+### Reproducible Builds
+
+You can compile [reproducible builds](https://reproducible-builds.org/) of the `mnemonikey` CLI tool for all platforms by executing the [`repro-build.sh` script](./repro-build.sh). The resulting binaries will be reproducible by anyone using the same `go` compiler version to build the same source code - even when cross-compiling across platforms.
+
+Note that these reproducible builds are compiled with [CGO](https://go.dev/blog/cgo) disabled, meaning they will be slightly less performant than a build with CGO enabled would be. Mnemonikey is not a performance-critical application, so most users will not notice any difference. It is, however, a _security-critical_ application. A maliciously built version of `mnemonikey` could expose a user's PGP key, or generate weak keys which an attacker could predict.
+
+With a small primary codebase and only a couple of dependencies, anyone can quickly audit Mnemonikey's codebase and dependencies for malicious interference or supply chain attacks. Once the source code is confirmed to be secure, a reproducibly compiled binary offers the guarantee that, _as long as the compiler is sound,_ so too is the binary. Thus, any user can verify the distributed builds of `mnemonikey` were compiled honestly, using the same source code.
+
 ## Background
 
 Normally, PGP key backups must be done manually by backing up private key export files, but files can be easily lost, corrupted, or deleted accidentally. Whenever new subkeys are added to the master key, the backup must be updated manually. This is a risky and error-prone practice, as I have personally discovered several times.

--- a/cmd/mnemonikey/go.mod
+++ b/cmd/mnemonikey/go.mod
@@ -1,6 +1,6 @@
 module github.com/kklash/mnemonikey/cmd/mnemonikey
 
-go 1.19
+go 1.20
 
 replace github.com/kklash/mnemonikey => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kklash/mnemonikey
 
-go 1.19
+go 1.20
 
 require (
 	github.com/kklash/wordlist4096 v0.0.0-20230128235818-1dcc136efd79

--- a/repro-build.sh
+++ b/repro-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+mkdir -p build
+
+export CGO_ENABLED=0
+export GOAMD64=v1
+export GO386=sse2
+
+GOVERSION="$(go env GOVERSION)"
+echo "Compiling reproducible builds."
+echo "  compiler version: $GOVERSION"
+echo "  git commit hash:  $(git rev-parse HEAD)"
+echo ""
+echo "The same compiler and source files must be used when reproducing builds."
+echo ""
+
+for os in linux windows darwin; do
+  for arch in 386 amd64 arm64; do
+    if [[ $arch == "386" ]] && [[ $os == "darwin" ]]; then
+      continue
+    elif [[ $arch == "arm64" ]] && [[ $os == "windows" ]]; then
+      continue
+    fi
+
+    outfile="mnemonikey-$os-$arch"
+    echo "Building $outfile..."
+
+     GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false -C ./cmd/mnemonikey -o "../../build/$outfile"
+  done
+done
+
+echo "Done. Artifacts compiled in ./build"
+echo ""
+shasum -a 256 build/*

--- a/repro-build.sh
+++ b/repro-build.sh
@@ -20,14 +20,12 @@ for os in linux windows darwin; do
   for arch in 386 amd64 arm64; do
     if [[ $arch == "386" ]] && [[ $os == "darwin" ]]; then
       continue
-    elif [[ $arch == "arm64" ]] && [[ $os == "windows" ]]; then
-      continue
     fi
 
     outfile="mnemonikey-$os-$arch"
     echo "Building $outfile..."
 
-     GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false -C ./cmd/mnemonikey -o "../../build/$outfile"
+    GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false -C ./cmd/mnemonikey -o "../../build/$outfile"
   done
 done
 


### PR DESCRIPTION
This PR adds a script to compile reproducible builds, by disabling CGO and hard-coding other environment-dependent build parameters.

Also adds a blurb in the readme for the curious.

Tested using go 1.20.4 compiler on the following platforms:
- [x] Debian 11
- [x] Ubuntu 20.04
- [x] Mac OS Ventura 13.0.1