### PR TITLE
feat: add -unsafe-entropy flag

### DIFF
--- a/cmd/mnemonikey/generate.go
+++ b/cmd/mnemonikey/generate.go
@@ -97,10 +97,12 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 		if opts.UnsafeEntropy == "-" {
 			entropySource = os.Stdin
 		} else {
-			entropySource, err = os.Open(opts.UnsafeEntropy)
+			file, err := os.Open(opts.UnsafeEntropy)
 			if err != nil {
 				return fmt.Errorf("failed to open entropy source file: %w", err)
 			}
+			defer file.Close()
+			entropySource = file
 		}
 	}
 

--- a/cmd/mnemonikey/generate.go
+++ b/cmd/mnemonikey/generate.go
@@ -22,6 +22,7 @@ type GenerateOptions struct {
 	GenerateConvertOptions
 
 	EncryptPhrase bool
+	UnsafeEntropy string
 }
 
 var GenerateCommand = &Command[GenerateOptions]{
@@ -46,6 +47,13 @@ var GenerateCommand = &Command[GenerateOptions]{
 			false,
 			"Encrypt the exported recovery phrase with a password. The resulting phrase will "+
 				"require the same password for later recovery.",
+		)
+		flags.StringVar(
+			&opts.UnsafeEntropy,
+			"unsafe-entropy",
+			"",
+			bold("(UNSAFE)")+" Generate the key using seed entropy drawn directly from the given `file`. "+
+				"Specify '-' to read entropy from standard input. "+bold("You probably shouldn't use this flag."),
 		)
 	},
 	Execute: func(opts *GenerateOptions, args []string) error {
@@ -77,7 +85,26 @@ func generateAndPrintKey(opts *GenerateOptions) error {
 	}
 	keyOptions.Subkeys = subkeyTypes
 
-	seed, err := mnemonikey.GenerateSeed(rand.Reader)
+	entropySource := rand.Reader
+	if opts.UnsafeEntropy != "" {
+		eprintln(
+			red(
+				bold("WARNING:") + " The -unsafe-entropy option is dangerous and can produce" +
+					" weak PGP keys if used incorrectly.",
+			),
+		)
+
+		if opts.UnsafeEntropy == "-" {
+			entropySource = os.Stdin
+		} else {
+			entropySource, err = os.Open(opts.UnsafeEntropy)
+			if err != nil {
+				return fmt.Errorf("failed to open entropy source file: %w", err)
+			}
+		}
+	}
+
+	seed, err := mnemonikey.GenerateSeed(entropySource)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/kklash/mnemonikey/issues/23

Adds a flag to the `generate` subcommand which allows a user to pull seed entropy from an arbitrary file or standard input. Added plenty of ominous warnings to ward off clueless folks from footgunning themselves. (they probably will still try)